### PR TITLE
Add build instruction for new versions

### DIFF
--- a/share/julia-build/v1.0.5
+++ b/share/julia-build/v1.0.5
@@ -1,0 +1,1 @@
+install_git "julia-v1.0.5" "https://github.com/JuliaLang/julia.git" "v1.0.5" "julia"

--- a/share/julia-build/v1.2.0
+++ b/share/julia-build/v1.2.0
@@ -1,0 +1,1 @@
+install_git "julia-v1.2.0" "https://github.com/JuliaLang/julia.git" "v1.2.0" "julia"

--- a/share/julia-build/v1.2.0-rc2
+++ b/share/julia-build/v1.2.0-rc2
@@ -1,0 +1,1 @@
+install_git "julia-v1.2.0-rc2" "https://github.com/JuliaLang/julia.git" "v1.2.0-rc2" "julia"

--- a/share/julia-build/v1.2.0-rc3
+++ b/share/julia-build/v1.2.0-rc3
@@ -1,0 +1,1 @@
+install_git "julia-v1.2.0-rc3" "https://github.com/JuliaLang/julia.git" "v1.2.0-rc3" "julia"

--- a/share/julia-build/v1.3.0
+++ b/share/julia-build/v1.3.0
@@ -1,0 +1,1 @@
+install_git "julia-v1.3.0" "https://github.com/JuliaLang/julia.git" "v1.3.0" "julia"

--- a/share/julia-build/v1.3.0-alpha
+++ b/share/julia-build/v1.3.0-alpha
@@ -1,0 +1,1 @@
+install_git "julia-v1.3.0-alpha" "https://github.com/JuliaLang/julia.git" "v1.3.0-alpha" "julia"

--- a/share/julia-build/v1.3.0-rc1
+++ b/share/julia-build/v1.3.0-rc1
@@ -1,0 +1,1 @@
+install_git "julia-v1.3.0-rc1" "https://github.com/JuliaLang/julia.git" "v1.3.0-rc1" "julia"

--- a/share/julia-build/v1.3.0-rc2
+++ b/share/julia-build/v1.3.0-rc2
@@ -1,0 +1,1 @@
+install_git "julia-v1.3.0-rc2" "https://github.com/JuliaLang/julia.git" "v1.3.0-rc2" "julia"

--- a/share/julia-build/v1.3.0-rc3
+++ b/share/julia-build/v1.3.0-rc3
@@ -1,0 +1,1 @@
+install_git "julia-v1.3.0-rc3" "https://github.com/JuliaLang/julia.git" "v1.3.0-rc3" "julia"

--- a/share/julia-build/v1.3.0-rc4
+++ b/share/julia-build/v1.3.0-rc4
@@ -1,0 +1,1 @@
+install_git "julia-v1.3.0-rc4" "https://github.com/JuliaLang/julia.git" "v1.3.0-rc4" "julia"

--- a/share/julia-build/v1.3.0-rc5
+++ b/share/julia-build/v1.3.0-rc5
@@ -1,0 +1,1 @@
+install_git "julia-v1.3.0-rc5" "https://github.com/JuliaLang/julia.git" "v1.3.0-rc5" "julia"

--- a/share/julia-build/v1.3.1
+++ b/share/julia-build/v1.3.1
@@ -1,0 +1,1 @@
+install_git "julia-v1.3.1" "https://github.com/JuliaLang/julia.git" "v1.3.1" "julia"

--- a/share/julia-build/v1.4.0
+++ b/share/julia-build/v1.4.0
@@ -1,0 +1,1 @@
+install_git "julia-v1.4.0" "https://github.com/JuliaLang/julia.git" "v1.4.0" "julia"

--- a/share/julia-build/v1.4.0-rc1
+++ b/share/julia-build/v1.4.0-rc1
@@ -1,0 +1,1 @@
+install_git "julia-v1.4.0-rc1" "https://github.com/JuliaLang/julia.git" "v1.4.0-rc1" "julia"

--- a/share/julia-build/v1.4.0-rc2
+++ b/share/julia-build/v1.4.0-rc2
@@ -1,0 +1,1 @@
+install_git "julia-v1.4.0-rc2" "https://github.com/JuliaLang/julia.git" "v1.4.0-rc2" "julia"

--- a/share/julia-build/v1.4.1
+++ b/share/julia-build/v1.4.1
@@ -1,0 +1,1 @@
+install_git "julia-v1.4.1" "https://github.com/JuliaLang/julia.git" "v1.4.1" "julia"

--- a/share/julia-build/v1.4.2
+++ b/share/julia-build/v1.4.2
@@ -1,0 +1,1 @@
+install_git "julia-v1.4.2" "https://github.com/JuliaLang/julia.git" "v1.4.2" "julia"

--- a/share/julia-build/v1.5.0
+++ b/share/julia-build/v1.5.0
@@ -1,0 +1,1 @@
+install_git "julia-v1.5.0" "https://github.com/JuliaLang/julia.git" "v1.5.0" "julia"

--- a/share/julia-build/v1.5.0-beta1
+++ b/share/julia-build/v1.5.0-beta1
@@ -1,0 +1,1 @@
+install_git "julia-v1.5.0-beta1" "https://github.com/JuliaLang/julia.git" "v1.5.0-beta1" "julia"

--- a/share/julia-build/v1.5.0-rc1
+++ b/share/julia-build/v1.5.0-rc1
@@ -1,0 +1,1 @@
+install_git "julia-v1.5.0-rc1" "https://github.com/JuliaLang/julia.git" "v1.5.0-rc1" "julia"

--- a/share/julia-build/v1.5.0-rc2
+++ b/share/julia-build/v1.5.0-rc2
@@ -1,0 +1,1 @@
+install_git "julia-v1.5.0-rc2" "https://github.com/JuliaLang/julia.git" "v1.5.0-rc2" "julia"


### PR DESCRIPTION
This PR extend the list of available versions to be up to date with Julia development. The follwing versions are included

- v1.0.5
- v1.2.0
- v1.2.0-rc2
- v1.2.0-rc3
- v1.3.0
- v1.3.0-alpha
- v1.3.0-rc1
- v1.3.0-rc2
- v1.3.0-rc3
- v1.3.0-rc4
- v1.3.0-rc5
- v1.3.1
- v1.4.0
- v1.4.0-rc1
- v1.4.0-rc2
- v1.4.1
- v1.4.2
- v1.5.0
- v1.5.0-beta1
- v1.5.0-rc1
- v1.5.0-rc2