### PR TITLE
update build instructions versions 1.2.0rc2 to 1.6.1

### DIFF
--- a/share/julia-build/v1.2.0-rc2
+++ b/share/julia-build/v1.2.0-rc2
@@ -1,0 +1,1 @@
+install_git "julia-v1.2.0-rc2" "https://github.com/JuliaLang/julia.git" "v1.2.0-rc2" "julia"

--- a/share/julia-build/v1.2.0-rc3
+++ b/share/julia-build/v1.2.0-rc3
@@ -1,0 +1,1 @@
+install_git "julia-v1.2.0-rc3" "https://github.com/JuliaLang/julia.git" "v1.2.0-rc3" "julia"

--- a/share/julia-build/v1.3.0
+++ b/share/julia-build/v1.3.0
@@ -1,0 +1,1 @@
+install_git "julia-v1.3.0" "https://github.com/JuliaLang/julia.git" "v1.3.0" "julia"

--- a/share/julia-build/v1.3.0-alpha
+++ b/share/julia-build/v1.3.0-alpha
@@ -1,0 +1,1 @@
+install_git "v1.3.0-alpha" "https://github.com/JuliaLang/julia.git" "v1.3.0-alpha" "julia"

--- a/share/julia-build/v1.3.0-rc1
+++ b/share/julia-build/v1.3.0-rc1
@@ -1,0 +1,1 @@
+install_git "v1.3.0-rc1" "https://github.com/JuliaLang/julia.git" "v1.3.0-rc1" "julia"

--- a/share/julia-build/v1.3.0-rc2
+++ b/share/julia-build/v1.3.0-rc2
@@ -1,0 +1,1 @@
+install_git "v1.3.0-rc2" "https://github.com/JuliaLang/julia.git" "v1.3.0-rc2" "julia"

--- a/share/julia-build/v1.3.0-rc3
+++ b/share/julia-build/v1.3.0-rc3
@@ -1,0 +1,1 @@
+install_git "v1.3.0-rc3" "https://github.com/JuliaLang/julia.git" "v1.3.0-rc3" "julia"

--- a/share/julia-build/v1.3.0-rc4
+++ b/share/julia-build/v1.3.0-rc4
@@ -1,0 +1,1 @@
+install_git "v1.3.0-rc4" "https://github.com/JuliaLang/julia.git" "v1.3.0-rc4" "julia"

--- a/share/julia-build/v1.3.0-rc5
+++ b/share/julia-build/v1.3.0-rc5
@@ -1,0 +1,1 @@
+install_git "v1.3.0-rc5" "https://github.com/JuliaLang/julia.git" "v1.3.0-rc5" "julia"

--- a/share/julia-build/v1.3.1
+++ b/share/julia-build/v1.3.1
@@ -1,0 +1,1 @@
+install_git "julia-v1.3.1" "https://github.com/JuliaLang/julia.git" "v1.3.1" "julia"

--- a/share/julia-build/v1.4.0
+++ b/share/julia-build/v1.4.0
@@ -1,0 +1,1 @@
+install_git "julia-v1.4.0" "https://github.com/JuliaLang/julia.git" "v1.4.0" "julia"

--- a/share/julia-build/v1.4.0-rc1
+++ b/share/julia-build/v1.4.0-rc1
@@ -1,0 +1,1 @@
+install_git "v1.4.0-rc1" "https://github.com/JuliaLang/julia.git" "v1.4.0-rc1" "julia"

--- a/share/julia-build/v1.4.0-rc2
+++ b/share/julia-build/v1.4.0-rc2
@@ -1,0 +1,1 @@
+install_git "v1.4.0-rc2" "https://github.com/JuliaLang/julia.git" "v1.4.0-rc2" "julia"

--- a/share/julia-build/v1.4.1
+++ b/share/julia-build/v1.4.1
@@ -1,0 +1,1 @@
+install_git "julia-v1.4.1" "https://github.com/JuliaLang/julia.git" "v1.4.1" "julia"

--- a/share/julia-build/v1.4.2
+++ b/share/julia-build/v1.4.2
@@ -1,0 +1,1 @@
+install_git "julia-v1.4.2" "https://github.com/JuliaLang/julia.git" "v1.4.2" "julia"

--- a/share/julia-build/v1.4.5
+++ b/share/julia-build/v1.4.5
@@ -1,0 +1,1 @@
+install_git "julia-v1.4.5" "https://github.com/JuliaLang/julia.git" "v1.4.5" "julia"

--- a/share/julia-build/v1.5.0
+++ b/share/julia-build/v1.5.0
@@ -1,0 +1,1 @@
+install_git "julia-v1.5.0" "https://github.com/JuliaLang/julia.git" "v1.5.0" "julia"

--- a/share/julia-build/v1.5.0-beta1
+++ b/share/julia-build/v1.5.0-beta1
@@ -1,0 +1,1 @@
+install_git "v1.5.0-beta1" "https://github.com/JuliaLang/julia.git" "v1.5.0-beta1" "julia"

--- a/share/julia-build/v1.5.0-rc1
+++ b/share/julia-build/v1.5.0-rc1
@@ -1,0 +1,1 @@
+install_git "v1.5.0-rc1" "https://github.com/JuliaLang/julia.git" "v1.5.0-rc1" "julia"

--- a/share/julia-build/v1.5.0-rc2
+++ b/share/julia-build/v1.5.0-rc2
@@ -1,0 +1,1 @@
+install_git "v1.5.0-rc1" "https://github.com/JuliaLang/julia.git" "v1.5.0-rc1" "julia"

--- a/share/julia-build/v1.5.1
+++ b/share/julia-build/v1.5.1
@@ -1,0 +1,1 @@
+install_git "julia-v1.5.1" "https://github.com/JuliaLang/julia.git" "v1.5.1" "julia"

--- a/share/julia-build/v1.5.2
+++ b/share/julia-build/v1.5.2
@@ -1,0 +1,1 @@
+install_git "julia-v1.5.2" "https://github.com/JuliaLang/julia.git" "v1.5.2" "julia"

--- a/share/julia-build/v1.5.3
+++ b/share/julia-build/v1.5.3
@@ -1,0 +1,1 @@
+install_git "julia-v1.5.3" "https://github.com/JuliaLang/julia.git" "v1.5.3" "julia"

--- a/share/julia-build/v1.5.4
+++ b/share/julia-build/v1.5.4
@@ -1,0 +1,1 @@
+install_git "julia-v1.5.4" "https://github.com/JuliaLang/julia.git" "v1.5.4" "julia"

--- a/share/julia-build/v1.6.0
+++ b/share/julia-build/v1.6.0
@@ -1,0 +1,1 @@
+install_git "julia-v1.6.0" "https://github.com/JuliaLang/julia.git" "v1.6.0" "julia"

--- a/share/julia-build/v1.6.0-beta1
+++ b/share/julia-build/v1.6.0-beta1
@@ -1,0 +1,1 @@
+install_git "v1.6.0-beta1" "https://github.com/JuliaLang/julia.git" "v1.6.0-beta1" "julia"

--- a/share/julia-build/v1.6.0-rc1
+++ b/share/julia-build/v1.6.0-rc1
@@ -1,0 +1,1 @@
+install_git "v1.6.0-rc1" "https://github.com/JuliaLang/julia.git" "v1.6.0-rc1" "julia"

--- a/share/julia-build/v1.6.0-rc2
+++ b/share/julia-build/v1.6.0-rc2
@@ -1,0 +1,1 @@
+install_git "v1.6.0-rc2" "https://github.com/JuliaLang/julia.git" "v1.6.0-rc2" "julia"

--- a/share/julia-build/v1.6.0-rc3
+++ b/share/julia-build/v1.6.0-rc3
@@ -1,0 +1,1 @@
+install_git "v1.6.0-rc3" "https://github.com/JuliaLang/julia.git" "v1.6.0-rc3" "julia"

--- a/share/julia-build/v1.6.1
+++ b/share/julia-build/v1.6.1
@@ -1,0 +1,1 @@
+install_git "julia-v1.6.1" "https://github.com/JuliaLang/julia.git" "v1.6.1" "julia"

--- a/share/julia-build/v1.6.2
+++ b/share/julia-build/v1.6.2
@@ -1,0 +1,1 @@
+install_git "julia-v1.6.2" "https://github.com/JuliaLang/julia.git" "v1.6.2" "julia"


### PR DESCRIPTION
Hey buddy, don't forget this awesome repo! Here is my help

---

Adding build instructions for new version:  

v1.2.0-rc2
v1.2.0-rc3
v1.3.0-alpha
v1.3.0-rc1
v1.3.0-rc2
v1.3.0-rc3
v1.3.0-rc4
v1.3.0-rc5
v1.3.0
v1.3.1
v1.4.0-rc1
v1.4.0-rc2
v1.4.0
v1.4.1
v1.4.2
v1.4.5
v1.5.0-beta1
v1.5.0-rc1
v1.5.0-rc2
v1.5.0
v1.5.1
v1.5.2
v1.5.3
v1.5.4
v1.6.0-beta1
v1.6.0-rc1
v1.6.0-rc2
v1.6.0-rc3
v1.6.0
v1.6.1
